### PR TITLE
JDK8の部分サポート

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,18 +23,24 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+
     implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    // TODO: jdk8 は要検討。
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     testImplementation 'junit:junit:4.12'
 


### PR DESCRIPTION
# 概要
- org.jetbrains.kotlin:kotlin-stdlib-jdk8 を採用
- desugaring 対応

# 完了条件
更新後の状態を成果物とする。